### PR TITLE
Only apply the windows workaround on R 3.3

### DIFF
--- a/R/redland/src/Makevars.win
+++ b/R/redland/src/Makevars.win
@@ -8,7 +8,7 @@ PKG_LIBS=-L../windows/redland-1.0.17/lib${R_ARCH} -lrdf \
 ## Workaround for missing _mkgmtime on Win32, See also
 ## https://sourceforge.net/p/mingw-w64/bugs/473/
 ifeq "${R_ARCH}" "/i386"
-PKG_LIBS += -lmsvcr100
+PKG_LIBS += ${subst gcc-4.9.3,-lmsvcr100,${COMPILED_BY}}
 endif
 
 PKG_CFLAGS=-DRASQAL_STATIC -DRAPTOR_STATIC -DREDLAND_STATIC


### PR DESCRIPTION
This slightly improves the windows workaround, so that it is only applied when needed.