### PR TITLE
Fix for ucrt on arm64

### DIFF
--- a/R/redland/src/Makevars.ucrt
+++ b/R/redland/src/Makevars.ucrt
@@ -1,2 +1,7 @@
-CRT=-ucrt
-include Makevars.win
+ifeq (,$(shell pkg-config --libs redland))
+  CRT=-ucrt
+  include Makevars.win
+else
+  PKG_CPPFLAGS=-DRASQAL_STATIC -DRAPTOR_STATIC -DREDLAND_STATIC $(shell pkg-config --cflags redland)
+  PKG_LIBS=$(shell pkg-config --libs-only-l redland)
+endif


### PR DESCRIPTION
This is the new recommended way to link to redland on Windows. This is needed to support the new aarch64 (arm64) toolchains on windows.